### PR TITLE
When wiping last line, don't add newline.

### DIFF
--- a/buffer.lua
+++ b/buffer.lua
@@ -334,7 +334,11 @@ function buffer.op_undo(b, sl)
 	if sl.op == "del" then
 		return b:bufins(sl, true)
 	elseif sl.op == "ins" then
-		return b:bufdel(sl.ci+#sl-1, sl.cj+ulen(sl[#sl]), true)
+		if #sl == 1 then -- Insertion was limited to part of a single line
+			return b:bufdel(sl.ci+#sl-1, sl.cj+ulen(sl[#sl]), true)
+		else -- Insertion spanned multiple lines
+			return b:bufdel(sl.ci+#sl-1, ulen(sl[#sl]), true)
+		end
 	else
 		return nil, "unknown op"
 	end

--- a/ple.lua
+++ b/ple.lua
@@ -678,12 +678,14 @@ function e.wipe(b, nokeep)
 	-- (default false)
 	if not b.si then
 		msg("No selection.")
-		if b:atlast() then -- add an empty line at end
-			e.goeot(b); e.nl(b); e.goup(b)
-		end
 		e.gohome(b)
 		local xi, xj
-		xi, xj = b.ci+1, 0
+		if b:atlast() then -- don't remove the newline
+			xi, xj = b:eol()
+			xj = xj + 1 -- include last character on line
+		else
+			xi, xj = b.ci+1, 0
+		end
 		if not nokeep then editor.kll = b:getlines(xi, xj) end
 		b:bufdel(xi, xj)
 		return


### PR DESCRIPTION
- Fix undo of multiline insertion. (from #5)
- When wiping last line, don't add newline.

The fixes a weirdness where wiping the last line is not undone by a
single ^Z, due to the newline insertion being a separate event in the
undo action list (b.ual). Thus, to get back to the state prior to a wipe
of the last line, two undos were required.

With this modification, the behavior when wiping the last line is
slightly modified. Specifically, the wipe does not include a newline at
the end (after all, there was no newline to wipe in the first place). As
a consequence, when yanking the wiped line, there we will also be no
newline at the end of the insert.

For precedence, this is consistent with the emacs ^K on the last line
(even if wipe behavior is not in general identical to ^K).