### PR TITLE
Allow to cancel quitting with ^X.

### DIFF
--- a/buffer.lua
+++ b/buffer.lua
@@ -334,7 +334,11 @@ function buffer.op_undo(b, sl)
 	if sl.op == "del" then
 		return b:bufins(sl, true)
 	elseif sl.op == "ins" then
-		return b:bufdel(sl.ci+#sl-1, sl.cj+ulen(sl[#sl]), true)
+		if #sl == 1 then -- Insertion was limited to part of a single line
+			return b:bufdel(sl.ci+#sl-1, sl.cj+ulen(sl[#sl]), true)
+		else -- Insertion spanned multiple lines
+			return b:bufdel(sl.ci+#sl-1, ulen(sl[#sl]), true)
+		end
 	else
 		return nil, "unknown op"
 	end

--- a/ple.lua
+++ b/ple.lua
@@ -727,7 +727,12 @@ function e.exiteditor(b)
 	end
 	if anyunsaved then
 		local ch = readchar(
-			"Some buffers not saved. Quit? ", "[YNQynq\r\n]")
+			"Some buffers not saved. Quit? ", "[YNQynq\r\n\24]")
+		if ch == "\24" then -- ^X
+			msg("^X")
+			e.prefix_ctlx(b)
+			return
+		end
 		if ch ~= "y" and ch ~= "Y" then
 			msg("aborted.")
 			return


### PR DESCRIPTION
- Fix undo of multiline insertion. (From #5)
- Allow to cancel quitting with ^X.

When quitting is blocked by unsaved files, allows to abort the quit by a
starting a ^X key sequence, without first dismissing the "Quit?"
question. The primary expected use is for the user to do ^X-^S, ^X-^C
when realizing that their buffer wasn't saved.

(Typing a 'n' or hitting return or enter before the ^X-^S may seem like
a small step, but my own experience is that I forget and want to go
straight to ^X-^s.)
