### PR TITLE
Luacheck suggestions

### DIFF
--- a/ple.lua
+++ b/ple.lua
@@ -308,7 +308,7 @@ local function adjcursor(buf)
 	local cx = buf.ci - buf.li + 1
 	local cy = 1 -- box column index, ignoring horizontal scroll
 --~ 	local cy = 0 -- box column index, ignoring horizontal scroll
-	local col = buf.box.c
+	local column = buf.box.c
 	local l = buf.ll[buf.ci]
 	local cj = 1
 	for p,c in utf8.codes(l) do
@@ -324,7 +324,7 @@ local function adjcursor(buf)
 	local hs = 0 -- horizontal scroll
 	local cys = cy -- actual box column index
 	while true do
-		if cys >= col then
+		if cys >= column then
 			cys = cys - 40
 			hs = hs + 40
 		else
@@ -1075,13 +1075,13 @@ local function main()
 		fname = "unnamed"
 	end
 	-- set term in raw mode
-	local prevmode, e, m = term.savemode()
-	if not prevmode then print(prevmode, e, m); os.exit() end
+	local prevmode, exitcode, m = term.savemode()
+	if not prevmode then print(prevmode, exitcode, m); os.exit() end
 	term.setrawmode()
 	term.reset()
 	-- run the application in a protected call so we can properly reset
 	-- the tty mode and display a traceback in case of error
-	local ok, msg = xpcall(editor_loop, debug.traceback, ll, fname)
+	local ok, message = xpcall(editor_loop, debug.traceback, ll, fname)
 	-- restore terminal in a a clean state
 	term.show() -- show cursor
 	term.left(999); term.down(999)
@@ -1089,7 +1089,7 @@ local function main()
 	flush()
 	term.restoremode(prevmode)
 	if not ok then -- display traceback in case of error
-		print(msg)
+		print(message)
 		os.exit(1)
 	end
 	print("\n") -- add an extra line  after the 'exiting' msg


### PR DESCRIPTION
This first commit avoid shadowing variables, ref https://github.com/philanc/ple/pull/8#issuecomment-1526489826

Luacheck reports a number of other things. Removing trailing whitespace is one, but I agree with [you](https://github.com/philanc/ple/pull/8#issuecomment-1526489826) that it is not important (and the suggestion can be disabled).

Complaining about globals #10 is another one.

Another one, which I think is quite meaningful as it can catch a mismatch between intent and behavior, is reporting unused variables or arguments. Some examples:

```
ple.lua:561:9: unused variable ci
ple.lua:723:6: unused loop variable i
ple.lua:768:23: unused argument b 
```

For the first two, the idea would be to replace the binding to `ci` or `i` with bindings to `_` which I understand is the convention to say explicitly that you are not interested in the value (as opposed to not using it due to a typo or other mistake in later code). For example, line 561 would become:

```lua
		local _, cj = b:getcur()
```

line 723:

```lua
	for _, bx in ipairs(editor.buflist) do
```

For line 768 (and several similar ones), I understand it the function will likely be called with the current buffer `b` (from a key binding), but the `b` is not used. I could understand why you might want to keep the argument to show the expected way it will be called.

```lua
function e.nextbuffer(b)
	-- switch to next buffer
	local bln = #editor.buflist
	editor.bufindex = editor.bufindex % bln + 1
	editor.buf = editor.buflist[editor.bufindex]
	editor.fullredisplay()
end--nextbuffer
```

In any case, if you are interested I can push more commits for things like the unused variables.

Note that I haven't run luacheck over `pleterm.lua` or `buffer.lua`. I thought it best to limit to `ple.lua` until I know what may interest you in terms of pull requests.