### PR TITLE
Make `editor` local.

### DIFF
--- a/ple.lua
+++ b/ple.lua
@@ -134,7 +134,7 @@ local style = core.style
 --	It contains variables and functions that can be used
 --	in ple_init.lua
 --	'editor' must be global to be visible in ple_init.lua
-editor = {}
+local editor = {}
 
 -- dialog functions
 
@@ -1051,17 +1051,18 @@ local function editor_loadinitfile()
 	-- function to be executed before entering the editor loop
 	-- could be used to load a configuration/initialization file
 	local initfile = os.getenv("PLE_INIT")
+	local env = {editor = editor, table.unpack(_G)}
 	if fileexists(initfile) then
-		return assert(loadfile(initfile))()
+		return assert(loadfile(initfile, nil, env))()
 	end
 	initfile = "./ple_init.lua"
 	if fileexists(initfile) then
-		return assert(loadfile(initfile))()
+		return assert(loadfile(initfile, nil, env))()
 	end
 	local homedir = os.getenv("HOME") or "~"
 	initfile = homedir .. "/.config/ple/ple_init.lua"
 	if fileexists(initfile) then
-		return assert(loadfile(initfile))()
+		return assert(loadfile(initfile, nil, env))()
 	end
 	return nil
 end--editor_loadinitfile


### PR DESCRIPTION
A benefit of making editor local would be that there is no risk of:

* accidentally using it in, for example, buffer.lua (I'm sure you wouldn't but maybe a well-meaning patch might…), or
* something silly like ple_init setting editor = nil breaking the editor (which now will cause the below but with https://github.com/philanc/ple/commit/933b2b3a48caaec1376e53c76db3d31ddf80f36c does not crash).

```
/Users/bjorn/repos/ple/ple.lua:220: attempt to index a nil value (global 'editor')                                              
stack traceback:
	/Users/bjorn/repos/ple/ple.lua:220: in field 'statusline'
	/Users/bjorn/repos/ple/ple.lua:348: in upvalue 'adjcursor'
	/Users/bjorn/repos/ple/ple.lua:391: in upvalue 'redisplay'
	/Users/bjorn/repos/ple/ple.lua:416: in field 'fullredisplay'
	/Users/bjorn/repos/ple/ple.lua:797: in field 'newbuffer'
	/Users/bjorn/repos/ple/ple.lua:1085: in function </Users/bjorn/repos/ple/ple.lua:1080>
	[C]: in function 'xpcall'
	/Users/bjorn/repos/ple/ple.lua:1133: in local 'main'
	/Users/bjorn/repos/ple/ple.lua:1147: in main chunk
	[C]: in function 'dofile'
	/Users/bjorn/bin/ple:5: in main chunk
	[C]: in
```

Supersedes #10.

