### PR TITLE
Fix file saving failure

### DIFF
--- a/ple.lua
+++ b/ple.lua
@@ -515,7 +515,7 @@ function e.del()
 	-- if selection, delete it. Else, delete char
 	local b = core.buf
 	if b.si then
-		return e.wipe(b, true) -- do not keep in wipe list
+		return e.wipe(true) -- do not keep in wipe list
 	end
 	if b:ateot() then return false end
 	local ci, cj = b:getcur()

--- a/ple.lua
+++ b/ple.lua
@@ -846,8 +846,7 @@ function e.writefile(fname)
 end--writefile
 
 function e.savefile()
-	local b = core.buf
-	e.writefile(b, b.filename)
+	e.writefile(core.buf.filename)
 end--savefile
 
 function e.gotoline(lineno)

--- a/ple.lua
+++ b/ple.lua
@@ -781,7 +781,7 @@ function e.newbuffer(fname, ll)
 	for i, bx in ipairs(core.buflist) do
 		if bx.filename == fname then
 			core.buf = bx; core.bufindex = i
-			core.fullredisplay(bx)
+			core.fullredisplay()
 			return bx
 		end
 	end
@@ -865,7 +865,7 @@ function e.help()
 	for i, bx in ipairs(core.buflist) do
 		if bx.filename == "*HELP*" then
 			core.buf = bx; core.bufindex = i
-			core.fullredisplay(bx)
+			core.fullredisplay()
 			return
 		end
 	end -- help buffer not found, then build it.


### PR DESCRIPTION
Crash on ^X^S. Stack trace below.

It seems there was a stray `b` in `savefile`'s call of `writefile` after you removed buffer params.

```
/Users/bjorn/repos/ple/ple.lua:839: bad argument #1 to 'open' (string expected, got table)                                      
stack traceback:                                                                                                                
        [C]: in function 'io.open'                                                                                              
        /Users/bjorn/repos/ple/ple.lua:839: in field 'writefile'                                                                
        /Users/bjorn/repos/ple/ple.lua:850: in function </Users/bjorn/repos/ple/ple.lua:848>                                    
        (...tail calls...)                                                                                                      
        [C]: in function 'xpcall'                                                                                               
        /Users/bjorn/repos/ple/ple.lua:1097: in function </Users/bjorn/repos/ple/ple.lua:1080>                                  
        [C]: in function 'xpcall'                                                                                               
        /Users/bjorn/repos/ple/ple.lua:1133: in local 'main'                                                                    
        /Users/bjorn/repos/ple/ple.lua:1147: in main chunk                                                                      
        [C]: in function 'dofile'                                                                                               
        /Users/bjorn/bin/ple:5: in main chunk                                                                                   
        [C]: in ?    
```