### PR TITLE
Start at first character after `settext`

### DIFF
--- a/buffer.lua
+++ b/buffer.lua
@@ -307,7 +307,7 @@ function buffer.settext(b, txt)
 	b.chgd = true
 	b.unsaved = true
 	b.ci = 1 -- line index
-	b.cj = 0 -- cursor offset
+	b.cj = 1 -- cursor offset
 	return true
 end--settext
 


### PR DESCRIPTION
Fixes behavior where otherwise the cursor position ends up at the end of the first line, but when keys are pressed it moves to the beginning of the line and starts inserting there. Furthermore, the first keypress cannot be undone!